### PR TITLE
Feat: add cc and bcc email lists to send_email method

### DIFF
--- a/src/python/email/example.py
+++ b/src/python/email/example.py
@@ -29,6 +29,12 @@ def main():
     # Define the list of email recipients
     email_receivers = ["receiver1@example.com", "receiver2@example.com"]
 
+    # Define the list of email cc recipients
+    cc_receivers = ["receivercc1@example.com", "receivercc2@example.com"]
+    
+    # Define the list of email blind carbon copy recipients
+    bcc_receivers = ["receiverbcc1@example.com", "receiverbcc2@example.com"]
+
     # Optionally, define a list of file paths to attach to the email
     file_paths = ["/path/to/attachment1.txt", "/path/to/attachment2.pdf"]
 
@@ -38,6 +44,8 @@ def main():
             html_template=html_template,
             subject=subject,
             email_receivers=email_receivers,
+            cc_email=cc_receivers,
+            bcc_email=bcc_receivers,
             file_paths=file_paths,
         )
         print("Email sent successfully!")


### PR DESCRIPTION
- Added support for cc_email and bcc_email parameters to send_email.
- Ensured cc_email and bcc_email are handled as optional lists, defaulting to empty if not provided.
- Updated docstrings to reflect new parameters for CC and BCC email functionality.